### PR TITLE
Refactor TableCell into dataclass and make IPython optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,6 @@ dependencies = [
     "beautifulsoup4",
     "pandas",
     "lxml",
-    "pre-commit>=4.2.0",
-    "pytest-cov>=6.2.1",
-    "ipython>=9.4.0",
 ]
 
 [project.optional-dependencies]
@@ -31,10 +28,10 @@ dev = [
     "ipython",
     "ipython-genutils",
     "pytest",
-    "pytest-cov",
+    "pytest-cov>=6.2.1",
     "ruff",
     "pyright",
-    "pre-commit",
+    "pre-commit>=4.2.0",
     "isort",
     "build",
     "twine",

--- a/tests/test_parse_table.py
+++ b/tests/test_parse_table.py
@@ -223,3 +223,27 @@ def test_parse_table_nested_tags():
 
     expected = pd.DataFrame([["Bold and italic"]], columns=["Text"])
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_parse_table_ignores_nested_tables():
+    html = """
+    <table>
+        <tr><th>A</th><th>B</th></tr>
+        <tr>
+            <td>1</td>
+            <td>
+                <table>
+                    <tr><td>x1</td><td>x2</td></tr>
+                </table>
+            </td>
+        </tr>
+        <tr><td>3</td><td>4</td></tr>
+    </table>
+    """
+    soup = BeautifulSoup(html, "lxml")
+    table_tag = soup.find("table")
+
+    result = parse_table(table_tag)
+
+    expected = pd.DataFrame([["1", "x1x2"], ["3", "4"]], columns=["A", "B"])
+    pd.testing.assert_frame_equal(result, expected)

--- a/uv.lock
+++ b/uv.lock
@@ -323,11 +323,8 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "ipython" },
     { name = "lxml" },
     { name = "pandas" },
-    { name = "pre-commit" },
-    { name = "pytest-cov" },
 ]
 
 [package.optional-dependencies]
@@ -336,10 +333,10 @@ dev = [
     { name = "ipython" },
     { name = "ipython-genutils" },
     { name = "isort" },
-    { name = "pre-commit" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-cov" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff" },
     { name = "twine" },
 ]
@@ -348,18 +345,15 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4" },
     { name = "build", marker = "extra == 'dev'" },
-    { name = "ipython", specifier = ">=9.4.0" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "ipython-genutils", marker = "extra == 'dev'" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "lxml" },
     { name = "pandas" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pre-commit", specifier = ">=4.2.0", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-cov", specifier = ">=6.2.1", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "twine", marker = "extra == 'dev'" },
 ]


### PR DESCRIPTION
## Summary
- simplify TableCell by using @dataclass with default list fields
- lazily import IPython in pretty_print and remove it from required dependencies
- avoid parsing nested tables by searching only immediate rows and cells
- move development tools like pre-commit and pytest-cov to the optional dev extras

## Testing
- `uv run pre-commit run --files pyproject.toml uv.lock`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68948bcf37988326b24f00eee7516ef8